### PR TITLE
Rename reserved keyword commands to execute

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -11,7 +11,7 @@ The following parameters are used to configure the plugin:
 * **key** - private SSH key for the remote machine
 * **sleep** - sleep for seconds between host connections
 * **timeout** - timeout for the tcp connection attempt
-* **commands** - list of commands to execute
+* **script** - list of commands to execute
 
 The following secret values can be set to configure the plugin.
 
@@ -50,7 +50,7 @@ pipeline:
     host: foo.com
     user: root
     port: 22
-    commands:
+    script:
       - echo hello
       - echo world
 ```
@@ -67,7 +67,7 @@ pipeline:
     user: root
     port: 22
     sleep: 5
-    commands:
+    script:
       - echo hello
       - echo world
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker run --rm \
   -e PLUGIN_HOST=foo.com \
   -e PLUGIN_USER=root \
   -e PLUGIN_KEY="$(cat ${HOME}/.ssh/id_rsa)" \
-  -e PLUGIN_COMMANDS=whoami \
+  -e PLUGIN_SCRIPT=whoami \
   -v $(pwd)/$(pwd) \
   -w $(pwd) \
   plugins/ssh

--- a/main.go
+++ b/main.go
@@ -51,9 +51,9 @@ func main() {
 			EnvVar: "PLUGIN_TIMEOUT,SSH_TIMEOUT",
 		},
 		cli.StringSliceFlag{
-			Name:   "commands",
+			Name:   "script",
 			Usage:  "execute commands",
-			EnvVar: "PLUGIN_COMMANDS,SSH_COMMANDS",
+			EnvVar: "PLUGIN_SCRIPT,SSH_SCRIPT",
 		},
 		cli.StringFlag{
 			Name:  "env-file",
@@ -79,7 +79,7 @@ func run(c *cli.Context) error {
 			Port:     c.Int("port"),
 			Sleep:    c.Int("sleep"),
 			Timeout:  c.Duration("timeout"),
-			Commands: c.StringSlice("commands"),
+			Script:   c.StringSlice("script"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -19,7 +19,7 @@ type (
 		Port     int           `json:"port"`
 		Sleep    int           `json:"sleep"`
 		Timeout  time.Duration `json:"timeout"`
-		Commands []string      `json:"commands"`
+		Script   []string      `json:"script"`
 	}
 
 	Plugin struct {
@@ -70,7 +70,7 @@ func (p Plugin) Exec() error {
 		session.Stdout = os.Stdout
 		session.Stderr = os.Stderr
 
-		if err := session.Run(strings.Join(p.Config.Commands, "\n")); err != nil {
+		if err := session.Run(strings.Join(p.Config.Script, "\n")); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
A change in the plugin API from 0.4 to 0.5 makes the commands keyword in the build config a reserved keyword and needs to be changed.

Ultimately I liked execute and just needed to get this going so that's what I went with